### PR TITLE
Branch experiment

### DIFF
--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -178,7 +178,9 @@
       <span *ngIf="model.recipientType === FeedbackParticipantType.TEAMS_EXCLUDING_SELF">This question is for other teams in this course and this course doesn't have any other team. Therefore, you will not be able to answer this question.</span>
       <span *ngIf="model.recipientType === FeedbackParticipantType.STUDENTS_EXCLUDING_SELF">This question is for other students in this course and this course doesn't have any other student. Therefore, you will not be able to answer this question.</span>
     </div>
-
+    <div *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS && !isFormEmpty()" class="col-12 constraint-margins">
+      <button type="button" (click)="triggerRecipientSubmissionFormClear()" [disabled]="isFormsDisabled" class="btn btn-light btn-sm">Clear Points</button>
+    </div> 
     <div class="row" *ngIf="model.recipientList.length > 0">
       <div class="col-12 text-center">
         <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"

--- a/src/web/app/components/question-submission-form/question-submission-form.component.html
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.html
@@ -180,7 +180,7 @@
     </div>
     <div *ngIf="model.questionType === FeedbackQuestionType.CONSTSUM_RECIPIENTS && !isFormEmpty()" class="col-12 constraint-margins">
       <button type="button" (click)="triggerRecipientSubmissionFormClear()" [disabled]="isFormsDisabled" class="btn btn-light btn-sm">Clear Points</button>
-    </div> 
+    </div>
     <div class="row" *ngIf="model.recipientList.length > 0">
       <div class="col-12 text-center">
         <button id="btn-submit-qn-{{ model.questionNumber }}" type="submit" class="btn btn-success"

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -185,7 +185,8 @@ export class QuestionSubmissionFormComponent implements OnInit {
    * Triggers the clearing of the recipient submission form.
    */
   triggerRecipientSubmissionFormClear(): void {
-    const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] = this.model.recipientSubmissionForms;
+    const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] =
+        this.model.recipientSubmissionForms;
     recipientSubmissionForms.forEach((form: FeedbackResponseRecipientSubmissionFormModel) => {
       const details: FeedbackConstantSumResponseDetails = form.responseDetails as FeedbackConstantSumResponseDetails;
       details.answers = [];
@@ -250,7 +251,8 @@ export class QuestionSubmissionFormComponent implements OnInit {
   }
 
   isFormEmpty(): boolean {
-    const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] = this.model.recipientSubmissionForms;
+    const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] =
+        this.model.recipientSubmissionForms;
     return recipientSubmissionForms.every((form: FeedbackResponseRecipientSubmissionFormModel) => {
       const details: FeedbackConstantSumResponseDetails = form.responseDetails as FeedbackConstantSumResponseDetails;
       return details.answers.length === 0;

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -250,6 +250,9 @@ export class QuestionSubmissionFormComponent implements OnInit {
         this.model.questionType, responseDetails);
   }
 
+  /**
+   * Checks whether the recipient submission form is empty or not.
+   */
   isFormEmpty(): boolean {
     const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] =
         this.model.recipientSubmissionForms;

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -3,6 +3,7 @@ import { FeedbackQuestionsService } from '../../../services/feedback-questions.s
 import { FeedbackResponsesService } from '../../../services/feedback-responses.service';
 import { VisibilityStateMachine } from '../../../services/visibility-state-machine';
 import {
+  FeedbackConstantSumResponseDetails,
   FeedbackParticipantType,
   FeedbackQuestionType, FeedbackResponseDetails, FeedbackTextQuestionDetails,
   FeedbackVisibilityType,
@@ -181,6 +182,21 @@ export class QuestionSubmissionFormComponent implements OnInit {
   }
 
   /**
+   * Triggers the clearing of the recipient submission form.
+   */
+  triggerRecipientSubmissionFormClear(): void {
+    const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] = this.model.recipientSubmissionForms;
+    recipientSubmissionForms.forEach((form: FeedbackResponseRecipientSubmissionFormModel) => {
+      const details: FeedbackConstantSumResponseDetails = form.responseDetails as FeedbackConstantSumResponseDetails;
+      details.answers = [];
+    });
+    this.formModelChange.emit({
+      ...this.model,
+      recipientSubmissionForms,
+    });
+  }
+
+  /**
    * Triggers deletion of a participant comment associated with the response.
    */
   triggerDeleteCommentEvent(index: number): void {
@@ -231,6 +247,14 @@ export class QuestionSubmissionFormComponent implements OnInit {
   isFeedbackResponseDetailsEmpty(responseDetails: FeedbackResponseDetails): boolean {
     return this.feedbackResponseService.isFeedbackResponseDetailsEmpty(
         this.model.questionType, responseDetails);
+  }
+
+  isFormEmpty(): boolean {
+    const recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[] = this.model.recipientSubmissionForms;
+    return recipientSubmissionForms.every((form: FeedbackResponseRecipientSubmissionFormModel) => {
+      const details: FeedbackConstantSumResponseDetails = form.responseDetails as FeedbackConstantSumResponseDetails;
+      return details.answers.length === 0;
+    });
   }
 
   /**

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -1835,6 +1835,16 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
               </tm-constsum-recipients-question-constraint>
             </div>
             <div
+              class="col-12 constraint-margins"
+            >
+              <button
+                class="btn btn-light btn-sm"
+                type="button"
+              >
+                Clear Points
+              </button>
+            </div>
+            <div
               class="row"
             >
               <div
@@ -4184,6 +4194,17 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </div>
                 </div>
               </tm-constsum-recipients-question-constraint>
+            </div>
+            <div
+              class="col-12 constraint-margins"
+            >
+              <button
+                class="btn btn-light btn-sm"
+                disabled=""
+                type="button"
+              >
+                Clear Points
+              </button>
             </div>
             <div
               class="row"


### PR DESCRIPTION
Added a "Clear points" button for the Constant Sum Recipient Question type.

Button only appears when there is at least one response for the constant sum recipient question. On click, all responses for the question will be cleared. Button will be disabled when the form is disabled.

https://user-images.githubusercontent.com/77200594/174020996-a9e31390-5b9a-429d-a311-c7f8f710751c.mp4

**Outline of Solution**
- Added method `triggerRecipientSubmissionFormClear()` to clear the responses in the recipient submission form
- Added method `isFormEmpty()` to check whether there are any responses in the form
- Added a "Clear points" button that appears if the question type is the constant sum recipient question type and `isFormEmpty()` returns false 
- Button calls `triggerRecipientSubmissionFormClear()` on click and is disabled when the form is disabled.